### PR TITLE
Ensure include directories are set for socket_test

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,9 @@
 add_executable(socket_test socket_test.cpp)
 target_link_libraries(socket_test GTest::gtest GTest::gtest_main)
+target_include_directories(
+  socket_test
+  PRIVATE ${CMAKE_SOURCE_DIR}/include
+)
 
 include(GoogleTest)
 gtest_discover_tests(socket_test)


### PR DESCRIPTION
Set include directory on the test target to ensure it builds.

Fixes #16 