### PR TITLE
Make it possible to compile sd_sockets as a subdirectory of another project

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,5 +6,7 @@ target_include_directories(
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include
 )
 
+target_compile_features(socket_test PRIVATE cxx_std_17)
+
 include(GoogleTest)
 gtest_discover_tests(socket_test)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,8 +1,9 @@
 add_executable(socket_test socket_test.cpp)
+
 target_link_libraries(socket_test GTest::gtest GTest::gtest_main)
 target_include_directories(
   socket_test
-  PRIVATE ${CMAKE_SOURCE_DIR}/include
+  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include
 )
 
 include(GoogleTest)


### PR DESCRIPTION
These changes make it possible to include `sd_sockets` as a sub-directory in another CMake project by simply using:
```
add_subdirectory(sd_sockets)
```